### PR TITLE
refactor(upper_assembly): restructure UpperAssembly hierarchy

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -16,7 +16,7 @@ import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.util.Units;
-import frc.robot.subsystems.UpperAssembly;
+import frc.robot.subsystems.upper_assembly.UpperAssembly;
 import frc.robot.util.DrivingMotor;
 import frc.robot.util.TurningMotor;
 import frc.robot.util.UpperAssemblyType;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -23,9 +23,10 @@ import edu.wpi.first.math.geometry.Pose2d;
 import frc.utils.UpperSubstructure;
 import frc.utils.DrivingMotor;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
-import frc.robot.subsystems.UpperAssembly;
 import frc.robot.subsystems.squid.SquidClimber;
 import frc.robot.subsystems.squid.SquidManipulator;
+import frc.robot.subsystems.upper_assembly.UpperAssembly;
+import frc.robot.subsystems.upper_assembly.UpperAssemblyBase;
 import frc.robot.util.UpperAssemblyFactory;
 import frc.robot.util.UpperAssemblyType;
 import edu.wpi.first.math.geometry.Transform3d;
@@ -57,7 +58,7 @@ public class RobotContainer {
     // Subsystems
     private final ExampleSubsystem exampleSubsystem = new ExampleSubsystem();
     private DriveSubsystem driveSubsystem = new DriveSubsystem();
-    private UpperAssembly upperAssembly = UpperAssemblyFactory.createUpperAssembly(Constants.UpperAssemblyConstants.DEFAULT_UPPER_ASSEMBLY);
+    private UpperAssemblyBase upperAssembly = UpperAssemblyFactory.createUpperAssembly(Constants.UpperAssemblyConstants.DEFAULT_UPPER_ASSEMBLY);
     
     private VisionOdometry visionOdometry = new VisionOdometry(driveSubsystem.getSwerveDrivePoseEstimator()); // TODO: Add logic to add cameras to adjust odometry. visionOdometry.addCamera(PhotonVisionCamera camera);
     

--- a/src/main/java/frc/robot/subsystems/narwhal/NarwhalUpperAssembly.java
+++ b/src/main/java/frc/robot/subsystems/narwhal/NarwhalUpperAssembly.java
@@ -6,10 +6,10 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.RunCommand;
-import frc.robot.subsystems.UpperAssembly;
+import frc.robot.subsystems.upper_assembly.UpperAssemblyBase;
 import frc.robot.util.ScoringHeight;
 
-public class NarwhalUpperAssembly implements UpperAssembly {
+public class NarwhalUpperAssembly extends UpperAssemblyBase {
     
     public Command getCoralIntakeCommand(Supplier<Pose2d> robotPoseSupplier) {
         return new RunCommand(

--- a/src/main/java/frc/robot/subsystems/squid/SquidUpperAssembly.java
+++ b/src/main/java/frc/robot/subsystems/squid/SquidUpperAssembly.java
@@ -8,10 +8,10 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import frc.robot.commands.squid.ManualSquidManipulatorCommand;
-import frc.robot.subsystems.UpperAssembly;
+import frc.robot.subsystems.upper_assembly.UpperAssemblyBase;
 import frc.robot.util.ScoringHeight;
 
-public class SquidUpperAssembly implements UpperAssembly {
+public class SquidUpperAssembly extends UpperAssemblyBase {
 
     SquidManipulator squidManipulator;
     

--- a/src/main/java/frc/robot/subsystems/upper_assembly/UpperAssembly.java
+++ b/src/main/java/frc/robot/subsystems/upper_assembly/UpperAssembly.java
@@ -1,11 +1,10 @@
-package frc.robot.subsystems;
+package frc.robot.subsystems.upper_assembly;
 
 import java.util.function.Supplier;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Subsystem;
 import frc.robot.util.ScoringHeight;
 
 /**
@@ -13,7 +12,7 @@ import frc.robot.util.ScoringHeight;
  * Provides methods for various assembly-specific actions such as scoring, intaking, climbing, 
  * and manual control. 
  */
-public interface UpperAssembly extends Subsystem {
+public interface UpperAssembly {
 
     /**
      * Creates a command to run the coral intake mechanism.

--- a/src/main/java/frc/robot/subsystems/upper_assembly/UpperAssemblyBase.java
+++ b/src/main/java/frc/robot/subsystems/upper_assembly/UpperAssemblyBase.java
@@ -2,10 +2,20 @@ package frc.robot.subsystems.upper_assembly;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
+/**
+ * <h2> UpperAssemblyBase </h2>
+ * An abstract class used to serve as an intermediary class between the {@link UpperAssembly} interface and the {@link SubsystemBase}
+ * abstract class. This class allows us to use SubsystemBase functionality on the upper assemblies without having the {@link SubsystemBase}
+ * interface extend the {@link SubsystemBase} class, preventing unexpected behavior due to an interface having pre-defined, functional code
+ * contained within methods.
+ * <hr>
+ * @author Cameron Myhre
+ * @since 2.0.0
+ */
 public abstract class UpperAssemblyBase extends SubsystemBase implements UpperAssembly {
     
     @Override
-    public void disable() {
+    public void disable() { // Basic implementation of the disable method. Ensures both teams have this defined.
         System.err.println("Error: Upper Assembly does not provide functionality to disable hardware in the event of an emergency.");
     }
 }

--- a/src/main/java/frc/robot/subsystems/upper_assembly/UpperAssemblyBase.java
+++ b/src/main/java/frc/robot/subsystems/upper_assembly/UpperAssemblyBase.java
@@ -1,0 +1,11 @@
+package frc.robot.subsystems.upper_assembly;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public abstract class UpperAssemblyBase extends SubsystemBase implements UpperAssembly {
+    
+    @Override
+    public void disable() {
+        System.err.println("Error: Upper Assembly does not provide functionality to disable hardware in the event of an emergency.");
+    }
+}

--- a/src/main/java/frc/robot/util/UpperAssemblyFactory.java
+++ b/src/main/java/frc/robot/util/UpperAssemblyFactory.java
@@ -1,12 +1,12 @@
 package frc.robot.util;
 
-import frc.robot.subsystems.UpperAssembly;
 import frc.robot.subsystems.narwhal.NarwhalUpperAssembly;
 import frc.robot.subsystems.squid.SquidUpperAssembly;
+import frc.robot.subsystems.upper_assembly.UpperAssemblyBase;
 
 public class UpperAssemblyFactory {
     
-    public static UpperAssembly createUpperAssembly(UpperAssemblyType upperAssemblyType) {
+    public static UpperAssemblyBase createUpperAssembly(UpperAssemblyType upperAssemblyType) {
         
         switch(upperAssemblyType) {
             case SQUID:


### PR DESCRIPTION
- Moved `UpperAssembly` interface to a new package `upper_assembly`.
- Introduced `UpperAssemblyBase` abstract class extending `SubsystemBase`.
- Updated implementations (`NarwhalUpperAssembly`, `SquidUpperAssembly`) to extend `UpperAssemblyBase`.
- Adjusted imports and references across the codebase to reflect these changes.