### PR TITLE
chore: add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve our software.
+title: ''
+labels: bug
+assignees: CameronMyhre
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+** Environment (please complete the following information):**
+ - Device Used: [e.g. MacBook]
+ - Driver: [e.g. name]
+ - Software Version: [e.g. 1.0.2]
+ - Driver Station Version: [e.g. (PLACEHOLDER VALUE)]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Add a new bug report template to guide users in reporting issues effectively. This includes sections for describing the bug, reproduction steps, expected behavior, environment details, and additional context.