### PR TITLE
feat(field): add ReefScoringLocation enum

### DIFF
--- a/src/main/java/frc/robot/util/field/ReefScoringLocation.java
+++ b/src/main/java/frc/robot/util/field/ReefScoringLocation.java
@@ -4,7 +4,8 @@ package frc.robot.util.field;
  * <h2> ReefScoringLocation </h2>
  * An enum value used to represent the different scoring locations along the reef. These values correspond and follow
  * FIRST`s own diagrams and standards.
- * @see <a href=https://firstfrc.blob.core.windows.net/frc2025/Manual/Sections/2025GameManual-05ARENA.pdf> FRC Reef Layout, PDF Page 6 </a>
+ * <hr>
+ * @see <a href=https://firstfrc.blob.core.windows.net/frc2025/Manual/Sections/2025GameManual-05ARENA.pdf> FRC Reef Layout </a> (PDF Page 6)
  */
 public enum ReefScoringLocation {
     A,

--- a/src/main/java/frc/robot/util/field/ReefScoringLocation.java
+++ b/src/main/java/frc/robot/util/field/ReefScoringLocation.java
@@ -1,0 +1,22 @@
+package frc.robot.util.field;
+
+/**
+ * <h2> ReefScoringLocation </h2>
+ * An enum value used to represent the different scoring locations along the reef. These values correspond and follow
+ * FIRST`s own diagrams and standards.
+ * @see <a href=https://firstfrc.blob.core.windows.net/frc2025/Manual/Sections/2025GameManual-05ARENA.pdf> FRC Reef Layout, PDF Page 6 </a>
+ */
+public enum ReefScoringLocation {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L;
+}


### PR DESCRIPTION
Introduce ReefScoringLocation enum to represent scoring locations along the reef, aligning with FIRST's diagrams and standards.