### PR TITLE
chore(build): update Gson dependency to version 2.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     annotationProcessor wpi.java.deps.wpilibAnnotations()
     implementation wpi.java.deps.wpilib()
     implementation wpi.java.vendor.java()
-    implementation 'com.google.code.gson:gson:2.8.9' // Use the latest version
+    implementation 'com.google.code.gson:gson:2.12.1'
     roborioDebug wpi.java.deps.wpilibJniDebug(wpi.platforms.roborio)
     roborioDebug wpi.java.vendor.jniDebug(wpi.platforms.roborio)
 


### PR DESCRIPTION
Updated the Gson library from version 2.8.9 to 2.12.1 in build.gradle to ensure compatibility with recent features and improvements.