### PR TITLE
feat(network): add port forwarding for photonvision2.local

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -36,6 +36,7 @@ public class Robot extends TimedRobot {
 
         // Allow the camera stream to be viewed via the robots network.
         PortForwarder.add(5800, "photonvision.local", 5800);
+        PortForwarder.add(5800, "photonvision2.local", 5800);
         PortForwarder.add(5000, "oceanview.local", 5000);
     }
 


### PR DESCRIPTION
Added a new port forwarding rule to allow camera stream access via photonvision2.local.