### PR TITLE
feat(odometry): enhance odometry update frequency

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -31,6 +31,12 @@ public class Robot extends TimedRobot {
         // autonomous chooser on the dashboard.
         robotContainer = new RobotContainer();
 
+        // Update the robot's odometry faster than the main loop times. (called every 4ms, offset by 10ms to prevent
+        // it from being called at the same time as the main loop).
+        addPeriodic(() -> {
+            robotContainer.updateOdometry();
+        }, 0.004, 0.01);
+
         // Automatically capture data with the driver camera.
         CameraServer.startAutomaticCapture();
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -188,4 +188,18 @@ public class RobotContainer {
         driveSubsystem.setDefaultCommand(manualDriveCommand);
         upperAssembly.setDefaultCommand(upperAssembly.getManualCommand(xBoxController));
     }
+
+
+    //////////////////////////////////////////////////////////////////////////////
+    // Periodic Update Methods
+    //////////////////////////////////////////////////////////////////////////////
+    
+    /**
+     * Updates the robot's odometry. This calls the {@code DriveSubsystem}'s {@code updateOdometry()} method and 
+     * the {@code VisionOdometry}'s {@code updateVisionPositionData()} method. 
+     */
+    public void updateOdometry() {
+        this.driveSubsystem.updateOdometry();
+        this.visionOdometry.updateVisionPositionData();
+    }
 }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -602,6 +602,21 @@ public class DriveSubsystem extends SubsystemBase {
     //////////////////////////////////////////////////////////////////////////////
 
     /**
+     * Updates the robot's odometry. This is done via a separate method to allow for faster update times
+     * than the base WPILib periodic method.
+     */
+    public void updateOdometry() {
+
+        // Update the robot's estimated pose using current sensor readings.
+        poseEstimator.update(getGyroscopeHeading(), getSwerveModulePositions());
+
+        // Display the data 
+        SmartDashboard.putNumber("X Position",getRobotPose().getX());
+        SmartDashboard.putNumber("Y Position",getRobotPose().getY());
+        SmartDashboard.putNumber("Theta Rotation", getRobotPose().getRotation().getRadians());
+    }
+
+    /**
      * Periodically updates the drive subsystem.
      * <p>
      * This method is called every cycle (even when disabled) and handles:
@@ -616,13 +631,6 @@ public class DriveSubsystem extends SubsystemBase {
     public void periodic() {
         // Update module states using the target velocities.
         setModules(targetVelocities);
-
-        // Update the robot's estimated pose using current sensor readings.
-        poseEstimator.update(getGyroscopeHeading(), getSwerveModulePositions());
-
-        SmartDashboard.putNumber("X Position",getRobotPose().getX());
-        SmartDashboard.putNumber("Y Position",getRobotPose().getY());
-        SmartDashboard.putNumber("Theta Rotation", getRobotPose().getRotation().getRadians());
 
         // Refresh dynamic pathfinding obstacles.
         pathfindingObstacles.clear();

--- a/src/main/java/frc/robot/subsystems/vision/odometry/VisionOdometry.java
+++ b/src/main/java/frc/robot/subsystems/vision/odometry/VisionOdometry.java
@@ -61,6 +61,17 @@ public class VisionOdometry extends SubsystemBase {
         cameras.add(camera);
     }
 
+     /**
+     * Periodically updates the robot's pose estimator with vision measurements 
+     * from all registered cameras.
+     * <p>
+     * This method is called automatically by the scheduler. For each camera:
+     * <ul>
+     *   <li>The current best estimate of the robot's pose is passed to the camera.</li>
+     *   <li>If the camera provides a valid vision-based pose estimate, it is 
+     *       added to the pose estimator with an appropriate timestamp.</li>
+     * </ul>
+     */
     public void updateVisionPositionData() {
 
         // Get the current best estimate of the robot's pose from the pose estimator
@@ -102,9 +113,6 @@ public class VisionOdometry extends SubsystemBase {
      */
     @Override
     public void periodic() {
-
-        // Updates the robot's position data.
-        updateVisionPositionData();
 
         // Display the robot's current position on the field.
         this.field2d.setRobotPose(this.poseEstimator.getEstimatedPosition());


### PR DESCRIPTION
Add a periodic task to update the robot's odometry every 4ms, offset by 10ms from the main loop. Introduce `updateOdometry` method in `RobotContainer`, which calls methods in `DriveSubsystem` and `VisionOdometry`. This change improves the accuracy of position tracking by separating odometry updates from the main periodic tasks.