### PR TITLE
feat(miscellaneous): add TimeWaitCommand for timed delays

### DIFF
--- a/src/main/java/frc/robot/miscellaneous/TimeWaitCommand.java
+++ b/src/main/java/frc/robot/miscellaneous/TimeWaitCommand.java
@@ -41,10 +41,4 @@ public class TimeWaitCommand extends Command {
     public boolean isFinished() {
         return System.nanoTime() >= completionTimeNanoseconds;
     }
-
-    // Called once the command ends or is interrupted.
-    @Override
-    public void end(boolean interrupted) {
-        // Cleanup, if necessary.
-    }
 }

--- a/src/main/java/frc/robot/miscellaneous/TimeWaitCommand.java
+++ b/src/main/java/frc/robot/miscellaneous/TimeWaitCommand.java
@@ -1,0 +1,50 @@
+package frc.robot.miscellaneous;
+
+import edu.wpi.first.wpilibj2.command.Command;
+
+public class TimeWaitCommand extends Command {
+
+    // Storage for the wait time in nanoseconds.
+    private final long waitTimeNanoseconds;
+    private long completionTimeNanoseconds;
+
+    /**
+     * Creates a new TimeWaitCommand.
+     *
+     * @param timeMilliseconds The time the command will wait for, in milliseconds. Must be non-negative.
+     * @throws IllegalArgumentException if timeMilliseconds is negative.
+     */
+    public TimeWaitCommand(double timeMilliseconds) {
+        if (timeMilliseconds < 0) {
+            throw new IllegalArgumentException("timeMilliseconds must be non-negative");
+        }
+        // Convert milliseconds to nanoseconds accurately.
+        this.waitTimeNanoseconds = Math.round(timeMilliseconds * 1000000L);
+    }
+
+    // Called when the command is initially scheduled.
+    @Override
+    public void initialize() {
+        completionTimeNanoseconds = System.nanoTime() + waitTimeNanoseconds;
+    }
+
+    // Called repeatedly while the command is scheduled.
+    @Override
+    public void execute() {
+        // No periodic action is necessary.
+    }
+
+    /**
+     * Returns true when the wait time has elapsed.
+     */
+    @Override
+    public boolean isFinished() {
+        return System.nanoTime() >= completionTimeNanoseconds;
+    }
+
+    // Called once the command ends or is interrupted.
+    @Override
+    public void end(boolean interrupted) {
+        // Cleanup, if necessary.
+    }
+}


### PR DESCRIPTION
Introduce a new `TimeWaitCommand` class to facilitate timed delays in command scheduling. The command waits for a specified duration, provided in milliseconds, before completing. It ensures the wait time is non-negative and accurately converts milliseconds to nanoseconds for precise timing.