### PR TITLE
chore: update GradleRIO and PathplannerLib versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import com.github.spotbugs.snom.SpotBugsTask
 plugins {
     id "java"
     id 'pmd'
-    id "edu.wpi.first.GradleRIO" version "2025.3.1"
+    id "edu.wpi.first.GradleRIO" version "2025.3.2"
     id "com.github.spotbugs" version "5.0.14"
 }
 

--- a/vendordeps/PathplannerLib-2025.2.6.json
+++ b/vendordeps/PathplannerLib-2025.2.6.json
@@ -1,7 +1,7 @@
 {
-    "fileName": "PathplannerLib-2025.2.5.json",
+    "fileName": "PathplannerLib-2025.2.6.json",
     "name": "PathplannerLib",
-    "version": "2025.2.5",
+    "version": "2025.2.6",
     "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
     "frcYear": "2025",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-java",
-            "version": "2025.2.5"
+            "version": "2025.2.6"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-cpp",
-            "version": "2025.2.5",
+            "version": "2025.2.6",
             "libName": "PathplannerLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
Updated GradleRIO plugin to version 2025.3.2 in build.gradle. Renamed and updated PathplannerLib vendordep file to version 2025.2.6, reflecting changes in the JSON metadata for consistency with the new library version.