### PR TITLE
fix(robot): update command for upper assembly intake

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -235,7 +235,7 @@ public class RobotContainer {
                         driveSubsystem.getScoringCommand(alliance, ReefScoringLocation.H)
                         .alongWith(upperAssembly.getCoralScoreCommand(ScoringHeight.L4))
                     ).andThen(
-                        upperAssembly.getCoralIntakeCommand()
+                        upperAssembly.getLowerCommand()
                     );
                 break;
             case RIGHT:


### PR DESCRIPTION
Changed the method call from `getCoralIntakeCommand()` to `getLowerCommand()` in the scoring sequence