### PR TITLE
pref(drive): optimize update frequencies for gyroscope and motors

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -179,6 +179,9 @@ public final class Constants {
         public static final double ROTATIONAL_KI = 0.0;
         public static final double ROTATIONAL_KD = 0.1;
 
+        // Update times
+        public static final int SENSOR_UPDATE_TIME_HZ = 250;
+
         /*
          * ---------------------------------- DRIVING CONSTANTS ----------------------------------
          */

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -209,10 +209,10 @@ public class DriveSubsystem extends SubsystemBase {
      * Updates the swerve drive configurations including upper assembly, motor, module, and auto-builder settings.
      */
     public void setConfigs() {
-
+        
         // IMU Configuration
         // Increase the gyroscope update speed. This puts it in sync with the rst of the code.
-        gyroscope.getYaw().setUpdateFrequency(250);
+        gyroscope.getYaw().setUpdateFrequency(DriveConstants.SENSOR_UPDATE_TIME_HZ);
 
         // --- Upper Assembly Configuration ---
         double upperAssemblyMass;

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -193,13 +193,12 @@ public class DriveSubsystem extends SubsystemBase {
     public DriveSubsystem() {
         // Enable continuous input for the rotational controller (wraps around at ±π).
         thetaController.enableContinuousInput(-Math.PI, Math.PI);
-
+        
         // Update all configuration settings (motor types, module configurations, etc.).
         setConfigs();
 
         Pathfinding.ensureInitialized();
         PathfindingCommand.warmupCommand();
-
     }
 
     //////////////////////////////////////////////////////////////////////////////
@@ -210,6 +209,11 @@ public class DriveSubsystem extends SubsystemBase {
      * Updates the swerve drive configurations including upper assembly, motor, module, and auto-builder settings.
      */
     public void setConfigs() {
+
+        // IMU Configuration
+        // Increase the gyroscope update speed. This puts it in sync with the rst of the code.
+        gyroscope.getYaw().setUpdateFrequency(250);
+
         // --- Upper Assembly Configuration ---
         double upperAssemblyMass;
         double upperAssemblyMOI;

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -209,9 +209,9 @@ public class DriveSubsystem extends SubsystemBase {
      * Updates the swerve drive configurations including upper assembly, motor, module, and auto-builder settings.
      */
     public void setConfigs() {
-        
+
         // IMU Configuration
-        // Increase the gyroscope update speed. This puts it in sync with the rst of the code.
+        // Increase the gyroscope update speed. This puts it in sync with the rest of the code.
         gyroscope.getYaw().setUpdateFrequency(DriveConstants.SENSOR_UPDATE_TIME_HZ);
 
         // --- Upper Assembly Configuration ---

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -18,6 +18,7 @@ import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Configs;
 import frc.robot.Constants.Defaults;
+import frc.robot.Constants.DriveConstants;
 import frc.robot.util.swerve.DrivingMotorType;
 import frc.robot.util.swerve.TurningMotorType;
 
@@ -216,24 +217,24 @@ public class SwerveModule extends SubsystemBase {
             case NEO:
                 drivingNeo = new SparkMax(drivingCANID,MotorType.kBrushless);
                 drivingNeo.configure(Configs.Swerve.Driving.NEO_DRIVING_CONFIG, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
+                drivingNeo.setControlFramePeriodMs(1 / DriveConstants.SENSOR_UPDATE_TIME_HZ);
                 drivingNeo.getEncoder().setPosition(0.0);
-                drivingNeo.setControlFramePeriodMs( 5);
                 drivingNeoSim = new SparkMaxSim(drivingNeo, DCMotor.getNEO(1));
                 break;
             
             case KRAKEN_X60:
                 drivingKrakenX60 = new TalonFX(drivingCANID);
                 drivingKrakenX60.getConfigurator().apply(Configs.Swerve.Driving.KRAKEN_X60_CONFIGURATION);
+                drivingKrakenX60.getPosition().setUpdateFrequency(DriveConstants.SENSOR_UPDATE_TIME_HZ);
                 drivingKrakenX60.setPosition(0.0);
-                drivingKrakenX60.getPosition().setUpdateFrequency(250);
                 drivingKrakenX60Sim = new TalonFXSimState(drivingKrakenX60);
                 break;
 
             case KRAKEN_X60_FOC:
                 drivingKrakenX60FOC = new TalonFX(drivingCANID);
                 drivingKrakenX60FOC.getConfigurator().apply(Configs.Swerve.Driving.KRAKEN_X60_FOC_CONFIGURATION);
+                drivingKrakenX60FOC.getPosition().setUpdateFrequency(DriveConstants.SENSOR_UPDATE_TIME_HZ);
                 drivingKrakenX60FOC.setPosition(0.0);
-                drivingKrakenX60FOC.getPosition().setUpdateFrequency(250);
                 drivingKrakenX60FOCSim = new TalonFXSimState(drivingKrakenX60FOC);
                 break;
         }
@@ -279,7 +280,7 @@ public class SwerveModule extends SubsystemBase {
             case NEO_550:
                 turningNeo550 = new SparkMax(turningCANID,MotorType.kBrushless);
                 turningNeo550.configure(Configs.Swerve.Turning.NEO_550_TURNING_CONFIG, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
-                turningNeo550.setControlFramePeriodMs(4);
+                turningNeo550.setControlFramePeriodMs(1 / DriveConstants.SENSOR_UPDATE_TIME_HZ);
                 turningNeo550Sim = new SparkMaxSim(turningNeo550, DCMotor.getNeo550(1));
                 break;
         }

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -7,6 +7,7 @@ import com.revrobotics.spark.SparkBase.ControlType;
 import com.revrobotics.spark.SparkBase.PersistMode;
 import com.revrobotics.spark.SparkBase.ResetMode;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
+import com.revrobotics.spark.SparkLowLevel.PeriodicFrame;
 import com.revrobotics.sim.SparkMaxSim;
 import com.revrobotics.spark.SparkMax;
 
@@ -216,6 +217,7 @@ public class SwerveModule extends SubsystemBase {
                 drivingNeo = new SparkMax(drivingCANID,MotorType.kBrushless);
                 drivingNeo.configure(Configs.Swerve.Driving.NEO_DRIVING_CONFIG, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
                 drivingNeo.getEncoder().setPosition(0.0);
+                drivingNeo.setControlFramePeriodMs( 5);
                 drivingNeoSim = new SparkMaxSim(drivingNeo, DCMotor.getNEO(1));
                 break;
             
@@ -223,6 +225,7 @@ public class SwerveModule extends SubsystemBase {
                 drivingKrakenX60 = new TalonFX(drivingCANID);
                 drivingKrakenX60.getConfigurator().apply(Configs.Swerve.Driving.KRAKEN_X60_CONFIGURATION);
                 drivingKrakenX60.setPosition(0.0);
+                drivingKrakenX60.getPosition().setUpdateFrequency(250);
                 drivingKrakenX60Sim = new TalonFXSimState(drivingKrakenX60);
                 break;
 
@@ -230,6 +233,7 @@ public class SwerveModule extends SubsystemBase {
                 drivingKrakenX60FOC = new TalonFX(drivingCANID);
                 drivingKrakenX60FOC.getConfigurator().apply(Configs.Swerve.Driving.KRAKEN_X60_FOC_CONFIGURATION);
                 drivingKrakenX60FOC.setPosition(0.0);
+                drivingKrakenX60FOC.getPosition().setUpdateFrequency(250);
                 drivingKrakenX60FOCSim = new TalonFXSimState(drivingKrakenX60FOC);
                 break;
         }
@@ -275,6 +279,7 @@ public class SwerveModule extends SubsystemBase {
             case NEO_550:
                 turningNeo550 = new SparkMax(turningCANID,MotorType.kBrushless);
                 turningNeo550.configure(Configs.Swerve.Turning.NEO_550_TURNING_CONFIG, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
+                turningNeo550.setControlFramePeriodMs(4);
                 turningNeo550Sim = new SparkMaxSim(turningNeo550, DCMotor.getNeo550(1));
                 break;
         }


### PR DESCRIPTION
Increased the gyroscope update speed to 250Hz in `DriveSubsystem` to synchronize with other components. Adjusted control frame periods and position update frequencies for various motor configurations in `SwerveModule` to enhance performance.