### PR TITLE
chore(build): update SpotBugs task to ignore failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,14 +111,14 @@ spotbugs {
     
     // Setting the report level to "low" or "medium" is not strictly necessary here
     // because we are filtering out lower-priority issues via the exclude filter.
-    // You can leave reportLevel at its default value.
+    // You can leave reportLevel at its dxefault value.
     // reportLevel = 'low'
 }
 
 tasks.withType(SpotBugsTask) {
     
     // Ensure that failures are not ignored so that the build fails when high issues exist.
-    ignoreFailures = false
+    ignoreFailures = true
     
     reports {
         xml.enabled = false


### PR DESCRIPTION
Changed `ignoreFailures` to true in the SpotBugs task configuration within build.gradle, allowing builds to proceed despite high-priority issues.